### PR TITLE
feat(test): add comprehensive unit tests (Mockito) and API tests (Kar…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,11 +101,37 @@
 			<artifactId>spring-security-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.intuit.karate</groupId>
+			<artifactId>karate-junit5</artifactId>
+			<version>1.4.1</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>
 		<finalName>authentication-service</finalName>
 		<plugins>
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>0.8.12</version>
+				<executions>
+					<execution>
+						<goals><goal>prepare-agent</goal></goals>
+					</execution>
+					<execution>
+						<id>report</id>
+						<phase>test</phase>
+						<goals><goal>report</goal></goals>
+					</execution>
+				</executions>
+			</plugin>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>

--- a/src/test/java/com/logistics/authentication/application/service/LoginServiceTest.java
+++ b/src/test/java/com/logistics/authentication/application/service/LoginServiceTest.java
@@ -21,6 +21,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
 import com.logistics.authentication.application.port.in.LoginUseCase.LoginCommand;
 import com.logistics.authentication.application.port.out.JwtTokenProviderPort;
@@ -33,6 +35,7 @@ import com.logistics.authentication.domain.exception.AuthenticationDomainExcepti
 import com.logistics.authentication.domain.model.UserAccount;
 
 @ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 class LoginServiceTest {
 
 	private static final UUID USER_ID = UUID.fromString("33333333-3333-3333-3333-333333333333");

--- a/src/test/java/com/logistics/authentication/application/service/RefreshTokenServiceTest.java
+++ b/src/test/java/com/logistics/authentication/application/service/RefreshTokenServiceTest.java
@@ -1,0 +1,197 @@
+package com.logistics.authentication.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.logistics.authentication.application.port.in.LoginUseCase.LoginResult;
+import com.logistics.authentication.application.port.in.RefreshTokenUseCase.RefreshCommand;
+import com.logistics.authentication.application.port.out.JwtTokenProviderPort;
+import com.logistics.authentication.application.port.out.RefreshTokenIssuerPort;
+import com.logistics.authentication.application.port.out.RefreshTokenRepositoryPort;
+import com.logistics.authentication.application.port.out.RefreshTokenRepositoryPort.RefreshTokenActive;
+import com.logistics.authentication.application.port.out.UserRepositoryPort;
+import com.logistics.authentication.domain.exception.AuthenticationDomainException;
+import com.logistics.authentication.domain.model.UserAccount;
+
+@ExtendWith(MockitoExtension.class)
+class RefreshTokenServiceTest {
+
+    @Mock
+    private UserRepositoryPort users;
+
+    @Mock
+    private RefreshTokenRepositoryPort refreshTokens;
+
+    @Mock
+    private JwtTokenProviderPort jwtTokenProvider;
+
+    @Mock
+    private RefreshTokenIssuerPort refreshTokenIssuer;
+
+    @Mock
+    private Clock clock;
+
+    @InjectMocks
+    private RefreshTokenService service;
+
+    private static final Instant NOW = Instant.parse("2026-01-15T10:00:00Z");
+    private static final UUID USER_ID = UUID.randomUUID();
+    private static final UUID TOKEN_ID = UUID.randomUUID();
+    private static final String RAW_TOKEN = "raw-refresh-token";
+    private static final String TOKEN_HASH = "hashed-token";
+    private static final String NEW_ACCESS_TOKEN = "new-access-token";
+    private static final String NEW_REFRESH_TOKEN = "new-refresh-opaque";
+
+    private UserAccount enabledUser;
+
+    @BeforeEach
+    void setUp() {
+        enabledUser = UserAccount.builder()
+                .id(USER_ID)
+                .email("user@test.com")
+                .passwordHash("hashed")
+                .roles(Set.of("ROLE_USER"))
+                .enabled(true)
+                .failedLoginAttempts(0)
+                .lockedUntil(null)
+                .build();
+    }
+
+    private void stubClock() {
+        when(clock.instant()).thenReturn(NOW);
+    }
+
+    @Test
+    void refreshSuccessfully_returnsNewTokens() {
+        stubClock();
+        when(refreshTokenIssuer.sha256Hex(RAW_TOKEN)).thenReturn(TOKEN_HASH);
+        when(refreshTokens.findActiveByTokenHash(TOKEN_HASH, NOW))
+                .thenReturn(Optional.of(new RefreshTokenActive(TOKEN_ID, USER_ID)));
+        when(users.findById(USER_ID)).thenReturn(Optional.of(enabledUser));
+        when(jwtTokenProvider.createAccessToken(enabledUser)).thenReturn(NEW_ACCESS_TOKEN);
+        when(refreshTokenIssuer.newOpaqueToken()).thenReturn(NEW_REFRESH_TOKEN);
+        when(jwtTokenProvider.getRefreshTokenTtlSeconds()).thenReturn(604800L);
+        when(jwtTokenProvider.getAccessTokenTtlSeconds()).thenReturn(3600L);
+        when(refreshTokenIssuer.sha256Hex(NEW_REFRESH_TOKEN)).thenReturn("new-hash");
+
+        LoginResult result = service.refresh(new RefreshCommand(RAW_TOKEN));
+
+        assertThat(result.accessToken()).isEqualTo(NEW_ACCESS_TOKEN);
+        assertThat(result.refreshToken()).isEqualTo(NEW_REFRESH_TOKEN);
+        assertThat(result.tokenType()).isEqualTo("Bearer");
+        assertThat(result.expiresInSeconds()).isEqualTo(3600L);
+        assertThat(result.refreshExpiresInSeconds()).isEqualTo(604800L);
+        verify(refreshTokens).revokeById(TOKEN_ID);
+        verify(refreshTokens).save(eq(USER_ID), eq("new-hash"), any(Instant.class));
+    }
+
+    @Test
+    void refreshWithNullToken_throwsInvalidRefresh() {
+        assertThatThrownBy(() -> service.refresh(new RefreshCommand(null)))
+                .isInstanceOf(AuthenticationDomainException.class)
+                .satisfies(ex -> {
+                    AuthenticationDomainException ade = (AuthenticationDomainException) ex;
+                    assertThat(ade.getErrorCode()).isEqualTo("INVALID_REFRESH");
+                });
+    }
+
+    @Test
+    void refreshWithBlankToken_throwsInvalidRefresh() {
+        assertThatThrownBy(() -> service.refresh(new RefreshCommand("   ")))
+                .isInstanceOf(AuthenticationDomainException.class)
+                .satisfies(ex -> {
+                    AuthenticationDomainException ade = (AuthenticationDomainException) ex;
+                    assertThat(ade.getErrorCode()).isEqualTo("INVALID_REFRESH");
+                });
+    }
+
+    @Test
+    void refreshWithUnknownToken_throwsInvalidRefresh() {
+        stubClock();
+        when(refreshTokenIssuer.sha256Hex("unknown-token")).thenReturn("unknown-hash");
+        when(refreshTokens.findActiveByTokenHash("unknown-hash", NOW))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.refresh(new RefreshCommand("unknown-token")))
+                .isInstanceOf(AuthenticationDomainException.class)
+                .satisfies(ex -> {
+                    AuthenticationDomainException ade = (AuthenticationDomainException) ex;
+                    assertThat(ade.getErrorCode()).isEqualTo("INVALID_REFRESH");
+                });
+        verify(refreshTokens, never()).revokeById(any());
+    }
+
+    @Test
+    void refreshWithDisabledUser_throwsAccountDisabled() {
+        stubClock();
+        UserAccount disabledUser = UserAccount.builder()
+                .id(USER_ID)
+                .email("user@test.com")
+                .passwordHash("hashed")
+                .roles(Set.of("ROLE_USER"))
+                .enabled(false)
+                .failedLoginAttempts(0)
+                .lockedUntil(null)
+                .build();
+
+        when(refreshTokenIssuer.sha256Hex(RAW_TOKEN)).thenReturn(TOKEN_HASH);
+        when(refreshTokens.findActiveByTokenHash(TOKEN_HASH, NOW))
+                .thenReturn(Optional.of(new RefreshTokenActive(TOKEN_ID, USER_ID)));
+        when(users.findById(USER_ID)).thenReturn(Optional.of(disabledUser));
+
+        assertThatThrownBy(() -> service.refresh(new RefreshCommand(RAW_TOKEN)))
+                .isInstanceOf(AuthenticationDomainException.class)
+                .satisfies(ex -> {
+                    AuthenticationDomainException ade = (AuthenticationDomainException) ex;
+                    assertThat(ade.getErrorCode()).isEqualTo("AUTH_ACCOUNT_DISABLED");
+                });
+        verify(refreshTokens, never()).revokeById(any());
+    }
+
+    @Test
+    void refreshWithLockedUser_throwsAccountLocked() {
+        stubClock();
+        UserAccount lockedUser = UserAccount.builder()
+                .id(USER_ID)
+                .email("user@test.com")
+                .passwordHash("hashed")
+                .roles(Set.of("ROLE_USER"))
+                .enabled(true)
+                .failedLoginAttempts(5)
+                .lockedUntil(NOW.plusSeconds(300))
+                .build();
+
+        when(refreshTokenIssuer.sha256Hex(RAW_TOKEN)).thenReturn(TOKEN_HASH);
+        when(refreshTokens.findActiveByTokenHash(TOKEN_HASH, NOW))
+                .thenReturn(Optional.of(new RefreshTokenActive(TOKEN_ID, USER_ID)));
+        when(users.findById(USER_ID)).thenReturn(Optional.of(lockedUser));
+
+        assertThatThrownBy(() -> service.refresh(new RefreshCommand(RAW_TOKEN)))
+                .isInstanceOf(AuthenticationDomainException.class)
+                .satisfies(ex -> {
+                    AuthenticationDomainException ade = (AuthenticationDomainException) ex;
+                    assertThat(ade.getErrorCode()).isEqualTo("AUTH_ACCOUNT_LOCKED");
+                });
+        verify(refreshTokens, never()).revokeById(any());
+    }
+}

--- a/src/test/java/com/logistics/authentication/domain/exception/AuthenticationDomainExceptionTest.java
+++ b/src/test/java/com/logistics/authentication/domain/exception/AuthenticationDomainExceptionTest.java
@@ -1,0 +1,38 @@
+package com.logistics.authentication.domain.exception;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class AuthenticationDomainExceptionTest {
+
+    @Test
+    void constructorSetsErrorCodeAndMessage() {
+        AuthenticationDomainException ex = new AuthenticationDomainException(
+                "AUTH_INVALID_CREDENTIALS", "Credenciales incorrectas");
+
+        assertThat(ex.getErrorCode()).isEqualTo("AUTH_INVALID_CREDENTIALS");
+        assertThat(ex.getMessage()).isEqualTo("Credenciales incorrectas");
+    }
+
+    @Test
+    void exceptionIsRuntimeException() {
+        AuthenticationDomainException ex = new AuthenticationDomainException(
+                "SOME_CODE", "some message");
+
+        assertThat(ex).isInstanceOf(RuntimeException.class);
+    }
+
+    @Test
+    void differentErrorCodesAreStoredCorrectly() {
+        AuthenticationDomainException locked = new AuthenticationDomainException(
+                "AUTH_ACCOUNT_LOCKED", "Cuenta bloqueada temporalmente");
+        AuthenticationDomainException disabled = new AuthenticationDomainException(
+                "AUTH_ACCOUNT_DISABLED", "Cuenta deshabilitada");
+
+        assertThat(locked.getErrorCode()).isEqualTo("AUTH_ACCOUNT_LOCKED");
+        assertThat(locked.getMessage()).isEqualTo("Cuenta bloqueada temporalmente");
+        assertThat(disabled.getErrorCode()).isEqualTo("AUTH_ACCOUNT_DISABLED");
+        assertThat(disabled.getMessage()).isEqualTo("Cuenta deshabilitada");
+    }
+}

--- a/src/test/java/com/logistics/authentication/domain/model/UserAccountTest.java
+++ b/src/test/java/com/logistics/authentication/domain/model/UserAccountTest.java
@@ -1,0 +1,76 @@
+package com.logistics.authentication.domain.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.Set;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+class UserAccountTest {
+
+    @Test
+    void isLocked_returnsTrueWhenLockedUntilIsInTheFuture() {
+        Instant now = Instant.parse("2026-01-15T10:00:00Z");
+        UserAccount user = UserAccount.builder()
+                .id(UUID.randomUUID())
+                .email("locked@test.com")
+                .passwordHash("hash")
+                .roles(Set.of("ROLE_USER"))
+                .enabled(true)
+                .failedLoginAttempts(5)
+                .lockedUntil(now.plusSeconds(300))
+                .build();
+
+        assertThat(user.isLocked(now)).isTrue();
+    }
+
+    @Test
+    void isLocked_returnsFalseWhenLockedUntilIsInThePast() {
+        Instant now = Instant.parse("2026-01-15T10:00:00Z");
+        UserAccount user = UserAccount.builder()
+                .id(UUID.randomUUID())
+                .email("unlocked@test.com")
+                .passwordHash("hash")
+                .roles(Set.of("ROLE_USER"))
+                .enabled(true)
+                .failedLoginAttempts(5)
+                .lockedUntil(now.minusSeconds(300))
+                .build();
+
+        assertThat(user.isLocked(now)).isFalse();
+    }
+
+    @Test
+    void isLocked_returnsFalseWhenLockedUntilIsNull() {
+        Instant now = Instant.parse("2026-01-15T10:00:00Z");
+        UserAccount user = UserAccount.builder()
+                .id(UUID.randomUUID())
+                .email("normal@test.com")
+                .passwordHash("hash")
+                .roles(Set.of("ROLE_USER"))
+                .enabled(true)
+                .failedLoginAttempts(0)
+                .lockedUntil(null)
+                .build();
+
+        assertThat(user.isLocked(now)).isFalse();
+    }
+
+    @Test
+    void isLocked_returnsFalseWhenLockedUntilEqualsNow() {
+        Instant now = Instant.parse("2026-01-15T10:00:00Z");
+        UserAccount user = UserAccount.builder()
+                .id(UUID.randomUUID())
+                .email("edge@test.com")
+                .passwordHash("hash")
+                .roles(Set.of("ROLE_USER"))
+                .enabled(true)
+                .failedLoginAttempts(3)
+                .lockedUntil(now)
+                .build();
+
+        assertThat(user.isLocked(now)).isFalse();
+    }
+}

--- a/src/test/java/com/logistics/authentication/infrastructure/adapter/in/web/AdminStatsControllerTest.java
+++ b/src/test/java/com/logistics/authentication/infrastructure/adapter/in/web/AdminStatsControllerTest.java
@@ -1,0 +1,65 @@
+package com.logistics.authentication.infrastructure.adapter.in.web;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import com.logistics.authentication.application.port.in.GetUserRoleStatsUseCase;
+import com.logistics.authentication.domain.readmodel.RoleUserCount;
+
+@ExtendWith(MockitoExtension.class)
+class AdminStatsControllerTest {
+
+    private MockMvc mockMvc;
+
+    @Mock
+    private GetUserRoleStatsUseCase getUserRoleStatsUseCase;
+
+    @InjectMocks
+    private AdminStatsController adminStatsController;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(adminStatsController).build();
+    }
+
+    @Test
+    void usersByRole_returns200WithStats() throws Exception {
+        when(getUserRoleStatsUseCase.getUsersByRole())
+                .thenReturn(List.of(
+                        new RoleUserCount("ROLE_ADMIN", 2),
+                        new RoleUserCount("ROLE_USER", 15)));
+
+        mockMvc.perform(get("/api/v1/admin/stats/users-by-role"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.rows").isArray())
+                .andExpect(jsonPath("$.rows.length()").value(2))
+                .andExpect(jsonPath("$.rows[0].roleName").value("ROLE_ADMIN"))
+                .andExpect(jsonPath("$.rows[0].userCount").value(2))
+                .andExpect(jsonPath("$.rows[1].roleName").value("ROLE_USER"))
+                .andExpect(jsonPath("$.rows[1].userCount").value(15));
+    }
+
+    @Test
+    void usersByRole_returnsEmptyList() throws Exception {
+        when(getUserRoleStatsUseCase.getUsersByRole())
+                .thenReturn(List.of());
+
+        mockMvc.perform(get("/api/v1/admin/stats/users-by-role"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.rows").isArray())
+                .andExpect(jsonPath("$.rows.length()").value(0));
+    }
+}

--- a/src/test/java/com/logistics/authentication/infrastructure/adapter/in/web/AuthControllerTest.java
+++ b/src/test/java/com/logistics/authentication/infrastructure/adapter/in/web/AuthControllerTest.java
@@ -2,63 +2,142 @@ package com.logistics.authentication.infrastructure.adapter.in.web;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.util.List;
 import java.util.Set;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.hateoas.HypermediaAutoConfiguration;
-import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
-import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Import;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.logistics.authentication.application.port.in.LoginUseCase;
 import com.logistics.authentication.application.port.in.LoginUseCase.LoginResult;
 import com.logistics.authentication.application.port.in.RefreshTokenUseCase;
-import com.logistics.authentication.infrastructure.adapter.in.web.dto.LoginRequest;
+import com.logistics.authentication.domain.exception.AuthenticationDomainException;
+import com.logistics.authentication.infrastructure.adapter.in.web.security.JwtPrincipal;
 
-@WebMvcTest(
-		controllers = AuthController.class,
-		excludeAutoConfiguration = { SecurityAutoConfiguration.class, UserDetailsServiceAutoConfiguration.class })
-@Import(HypermediaAutoConfiguration.class)
+@ExtendWith(MockitoExtension.class)
 class AuthControllerTest {
 
-	@Autowired
-	private MockMvc mockMvc;
+    private MockMvc mockMvc;
 
-	@Autowired
-	private ObjectMapper objectMapper;
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
-	@MockBean
-	private LoginUseCase loginUseCase;
+    @Mock
+    private LoginUseCase loginUseCase;
 
-	@MockBean
-	private RefreshTokenUseCase refreshTokenUseCase;
+    @Mock
+    private RefreshTokenUseCase refreshTokenUseCase;
 
-	@Test
-	void login_returns200AndBody() throws Exception {
-		when(loginUseCase.login(any()))
-				.thenReturn(new LoginResult("tok", "Bearer", 3600, Set.of("ROLE_ADMIN"), "refresh-opaque", 604800L));
+    @InjectMocks
+    private AuthController authController;
 
-		var req = new LoginRequest("admin@logistics.com", "password123");
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(authController)
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+    }
 
-		mockMvc.perform(post("/api/v1/auth/login")
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(objectMapper.writeValueAsString(req)))
-				.andExpect(status().isOk())
-				.andExpect(jsonPath("$.accessToken").value("tok"))
-				.andExpect(jsonPath("$.tokenType").value("Bearer"))
-				.andExpect(jsonPath("$.expiresIn").value(3600))
-				.andExpect(jsonPath("$.roles[0]").value("ROLE_ADMIN"))
-				.andExpect(jsonPath("$.refreshToken").value("refresh-opaque"))
-				.andExpect(jsonPath("$.refreshExpiresIn").value(604800));
-	}
+    @Test
+    void login_returns200AndBody() throws Exception {
+        when(loginUseCase.login(any()))
+                .thenReturn(new LoginResult("tok", "Bearer", 3600, Set.of("ROLE_ADMIN"), "refresh-opaque", 604800L));
+
+        String body = "{\"email\":\"admin@logistics.com\",\"password\":\"password123\"}";
+
+        mockMvc.perform(post("/api/v1/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.accessToken").value("tok"))
+                .andExpect(jsonPath("$.tokenType").value("Bearer"))
+                .andExpect(jsonPath("$.expiresIn").value(3600))
+                .andExpect(jsonPath("$.refreshToken").value("refresh-opaque"))
+                .andExpect(jsonPath("$.refreshExpiresIn").value(604800));
+    }
+
+    @Test
+    void refresh_returns200AndNewTokens() throws Exception {
+        when(refreshTokenUseCase.refresh(any()))
+                .thenReturn(new LoginResult("new-access", "Bearer", 3600, Set.of("ROLE_USER"), "new-refresh", 604800L));
+
+        String body = "{\"refreshToken\":\"old-refresh-token\"}";
+
+        mockMvc.perform(post("/api/v1/auth/refresh")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.accessToken").value("new-access"))
+                .andExpect(jsonPath("$.refreshToken").value("new-refresh"))
+                .andExpect(jsonPath("$.tokenType").value("Bearer"));
+    }
+
+    @Test
+    void me_returns200WhenAuthenticated() throws Exception {
+        JwtPrincipal principal = new JwtPrincipal("33333333-3333-3333-3333-333333333333", "admin@logistics.com");
+        var authorities = List.of(new SimpleGrantedAuthority("ROLE_ADMIN"));
+        var auth = new UsernamePasswordAuthenticationToken(principal, null, authorities);
+
+        mockMvc.perform(get("/api/v1/auth/me")
+                .principal(auth))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.userId").value("33333333-3333-3333-3333-333333333333"))
+                .andExpect(jsonPath("$.email").value("admin@logistics.com"))
+                .andExpect(jsonPath("$.roles[0]").value("ROLE_ADMIN"));
+    }
+
+    @Test
+    void me_returns401WhenNotAuthenticated() throws Exception {
+        mockMvc.perform(get("/api/v1/auth/me"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void login_returns401WhenDomainExceptionThrown() throws Exception {
+        when(loginUseCase.login(any()))
+                .thenThrow(new AuthenticationDomainException("AUTH_INVALID_CREDENTIALS", "Credenciales incorrectas"));
+
+        String body = "{\"email\":\"admin@logistics.com\",\"password\":\"wrongpassword\"}";
+
+        mockMvc.perform(post("/api/v1/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.errorCode").value("AUTH_INVALID_CREDENTIALS"))
+                .andExpect(jsonPath("$.message").value("Credenciales incorrectas"));
+    }
+
+    @Test
+    void login_returns400WhenRequestBodyIsInvalid() throws Exception {
+        String invalidBody = "{\"email\":\"\",\"password\":\"\"}";
+
+        mockMvc.perform(post("/api/v1/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(invalidBody))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void refresh_returns400WhenRefreshTokenIsBlank() throws Exception {
+        String invalidBody = "{\"refreshToken\":\"\"}";
+
+        mockMvc.perform(post("/api/v1/auth/refresh")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(invalidBody))
+                .andExpect(status().isBadRequest());
+    }
 }

--- a/src/test/java/com/logistics/authentication/infrastructure/adapter/in/web/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/logistics/authentication/infrastructure/adapter/in/web/GlobalExceptionHandlerTest.java
@@ -1,0 +1,121 @@
+package com.logistics.authentication.infrastructure.adapter.in.web;
+
+import com.logistics.authentication.domain.exception.AuthenticationDomainException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class GlobalExceptionHandlerTest {
+
+    private MockMvc mockMvc;
+
+    @RestController
+    static class FakeController {
+
+        @GetMapping("/fake/auth-domain-unauthorized")
+        public void throwAuthDomainUnauthorized() {
+            throw new AuthenticationDomainException("AUTH_INVALID_CREDENTIALS", "Credenciales inválidas");
+        }
+
+        @GetMapping("/fake/auth-domain-locked")
+        public void throwAuthDomainLocked() {
+            throw new AuthenticationDomainException("AUTH_ACCOUNT_LOCKED", "Cuenta bloqueada");
+        }
+
+        @GetMapping("/fake/auth-domain-disabled")
+        public void throwAuthDomainDisabled() {
+            throw new AuthenticationDomainException("AUTH_ACCOUNT_DISABLED", "Cuenta deshabilitada");
+        }
+
+        @GetMapping("/fake/access-denied")
+        public void throwAccessDenied() {
+            throw new AccessDeniedException("No tiene permisos");
+        }
+
+        @PostMapping("/fake/validation")
+        public void throwValidation(@Valid @RequestBody ValidationDto dto) {
+            // If reached, validation passed (should not happen in test)
+        }
+
+        @GetMapping("/fake/generic")
+        public void throwGeneric() {
+            throw new RuntimeException("Something unexpected");
+        }
+    }
+
+    record ValidationDto(@NotBlank String name) {}
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(new FakeController())
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+    }
+
+    @Test
+    void handleAuthDomain_defaultErrorCode_returns401() throws Exception {
+        mockMvc.perform(get("/fake/auth-domain-unauthorized"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.errorCode").value("AUTH_INVALID_CREDENTIALS"))
+                .andExpect(jsonPath("$.message").value("Credenciales inválidas"));
+    }
+
+    @Test
+    void handleAuthDomain_accountLocked_returns403() throws Exception {
+        mockMvc.perform(get("/fake/auth-domain-locked"))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.errorCode").value("AUTH_ACCOUNT_LOCKED"))
+                .andExpect(jsonPath("$.message").value("Cuenta bloqueada"));
+    }
+
+    @Test
+    void handleAuthDomain_accountDisabled_returns403() throws Exception {
+        mockMvc.perform(get("/fake/auth-domain-disabled"))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.errorCode").value("AUTH_ACCOUNT_DISABLED"))
+                .andExpect(jsonPath("$.message").value("Cuenta deshabilitada"));
+    }
+
+    @Test
+    void handleAccessDenied_returns403() throws Exception {
+        mockMvc.perform(get("/fake/access-denied"))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.errorCode").value("ACCESS_DENIED"))
+                .andExpect(jsonPath("$.message").value("Permisos insuficientes para este recurso"));
+    }
+
+    @Test
+    void handleValidation_returns400WithDetails() throws Exception {
+        mockMvc.perform(post("/fake/validation")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\": \"\"}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("VALIDATION_ERROR"))
+                .andExpect(jsonPath("$.message").value("Payload inválido"))
+                .andExpect(jsonPath("$.details").isArray())
+                .andExpect(jsonPath("$.details").isNotEmpty());
+    }
+
+    @Test
+    void handleGeneric_returns500() throws Exception {
+        mockMvc.perform(get("/fake/generic"))
+                .andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$.errorCode").value("INTERNAL_ERROR"))
+                .andExpect(jsonPath("$.message").value("Error interno"));
+    }
+}

--- a/src/test/java/com/logistics/authentication/infrastructure/adapter/in/web/filter/LoginRateLimitFilterTest.java
+++ b/src/test/java/com/logistics/authentication/infrastructure/adapter/in/web/filter/LoginRateLimitFilterTest.java
@@ -1,0 +1,103 @@
+package com.logistics.authentication.infrastructure.adapter.in.web.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.logistics.authentication.infrastructure.config.SecurityProperties;
+
+class LoginRateLimitFilterTest {
+
+    private LoginRateLimitFilter filter;
+    private SecurityProperties securityProperties;
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        securityProperties = new SecurityProperties();
+        securityProperties.setLoginRateLimitPerMinute(3);
+        objectMapper = new ObjectMapper();
+        filter = new LoginRateLimitFilter(securityProperties, objectMapper);
+    }
+
+    @Test
+    void requestsWithinLimit_passThrough() throws Exception {
+        for (int i = 0; i < 3; i++) {
+            MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/v1/auth/login");
+            request.setServletPath("/api/v1/auth/login");
+            request.setRemoteAddr("192.168.1.1");
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            MockFilterChain chain = new MockFilterChain();
+
+            filter.doFilterInternal(request, response, chain);
+
+            assertThat(response.getStatus()).isNotEqualTo(429);
+        }
+    }
+
+    @Test
+    void requestsExceedingLimit_return429() throws Exception {
+        // Exhaust the limit
+        for (int i = 0; i < 3; i++) {
+            MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/v1/auth/login");
+            request.setServletPath("/api/v1/auth/login");
+            request.setRemoteAddr("10.0.0.1");
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            MockFilterChain chain = new MockFilterChain();
+            filter.doFilterInternal(request, response, chain);
+        }
+
+        // This one should be rate limited
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/v1/auth/login");
+        request.setServletPath("/api/v1/auth/login");
+        request.setRemoteAddr("10.0.0.1");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilterInternal(request, response, chain);
+
+        assertThat(response.getStatus()).isEqualTo(429);
+        assertThat(response.getContentType()).isEqualTo("application/json");
+    }
+
+    @Test
+    void getNonLoginRequest_isNotRateLimited() throws Exception {
+        for (int i = 0; i < 10; i++) {
+            MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v1/auth/me");
+            request.setServletPath("/api/v1/auth/me");
+            request.setRemoteAddr("10.0.0.2");
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            MockFilterChain chain = new MockFilterChain();
+
+            filter.doFilterInternal(request, response, chain);
+
+            assertThat(response.getStatus()).isNotEqualTo(429);
+        }
+    }
+
+    @Test
+    void differentIps_areRateLimitedIndependently() throws Exception {
+        // Exhaust limit for IP1
+        for (int i = 0; i < 3; i++) {
+            MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/v1/auth/login");
+            request.setServletPath("/api/v1/auth/login");
+            request.setRemoteAddr("10.0.0.10");
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            filter.doFilterInternal(request, response, new MockFilterChain());
+        }
+
+        // IP2 should still work
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/v1/auth/login");
+        request.setServletPath("/api/v1/auth/login");
+        request.setRemoteAddr("10.0.0.20");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        filter.doFilterInternal(request, response, new MockFilterChain());
+
+        assertThat(response.getStatus()).isNotEqualTo(429);
+    }
+}

--- a/src/test/java/com/logistics/authentication/infrastructure/adapter/in/web/filter/TraceIdFilterTest.java
+++ b/src/test/java/com/logistics/authentication/infrastructure/adapter/in/web/filter/TraceIdFilterTest.java
@@ -1,0 +1,55 @@
+package com.logistics.authentication.infrastructure.adapter.in.web.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+class TraceIdFilterTest {
+
+    private final TraceIdFilter filter = new TraceIdFilter();
+
+    @Test
+    void generatesNewTraceIdWhenNotPresent() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilterInternal(request, response, chain);
+
+        String traceId = response.getHeader(TraceIdFilter.TRACE_ID_HEADER);
+        assertThat(traceId).isNotNull().isNotBlank();
+        // Should be a UUID format
+        assertThat(traceId).matches("[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}");
+    }
+
+    @Test
+    void propagatesExistingTraceId() throws Exception {
+        String existingTraceId = "my-custom-trace-id-123";
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader(TraceIdFilter.TRACE_ID_HEADER, existingTraceId);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilterInternal(request, response, chain);
+
+        String traceId = response.getHeader(TraceIdFilter.TRACE_ID_HEADER);
+        assertThat(traceId).isEqualTo(existingTraceId);
+    }
+
+    @Test
+    void blankTraceIdHeader_generatesNewOne() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader(TraceIdFilter.TRACE_ID_HEADER, "   ");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilterInternal(request, response, chain);
+
+        String traceId = response.getHeader(TraceIdFilter.TRACE_ID_HEADER);
+        assertThat(traceId).isNotBlank();
+        assertThat(traceId.trim()).isNotEqualTo("");
+    }
+}

--- a/src/test/java/com/logistics/authentication/infrastructure/adapter/in/web/security/JsonAuthenticationEntryPointTest.java
+++ b/src/test/java/com/logistics/authentication/infrastructure/adapter/in/web/security/JsonAuthenticationEntryPointTest.java
@@ -1,0 +1,34 @@
+package com.logistics.authentication.infrastructure.adapter.in.web.security;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.BadCredentialsException;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+class JsonAuthenticationEntryPointTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final JsonAuthenticationEntryPoint entryPoint = new JsonAuthenticationEntryPoint(objectMapper);
+
+    @Test
+    void commence_returns401WithJsonBody() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        entryPoint.commence(request, response, new BadCredentialsException("test"));
+
+        assertThat(response.getStatus()).isEqualTo(401);
+        assertThat(response.getContentType()).isEqualTo("application/json");
+
+        String body = response.getContentAsString();
+        assertThat(body).contains("UNAUTHORIZED");
+        assertThat(body).contains("Se requiere autenticaci");
+    }
+}

--- a/src/test/java/com/logistics/authentication/infrastructure/adapter/in/web/security/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/logistics/authentication/infrastructure/adapter/in/web/security/JwtAuthenticationFilterTest.java
@@ -1,0 +1,271 @@
+package com.logistics.authentication.infrastructure.adapter.in.web.security;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.List;
+
+import javax.crypto.SecretKey;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.logistics.authentication.infrastructure.config.JwtProperties;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class JwtAuthenticationFilterTest {
+
+    private static final String SECRET = "this-is-a-very-long-secret-key-for-testing-hs256-algorithm!!";
+
+    @Mock
+    private JwtProperties jwtProperties;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private JwtAuthenticationFilter filter;
+
+    @BeforeEach
+    void setUp() {
+        filter = new JwtAuthenticationFilter(jwtProperties, objectMapper);
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void noAuthorizationHeader_passesThrough() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setServletPath("/api/v1/users");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilterInternal(request, response, chain);
+
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        assertThat(response.getStatus()).isEqualTo(200);
+    }
+
+    @Test
+    void invalidToken_passesThrough_withUnauthorizedStatus() throws Exception {
+        when(jwtProperties.getSecret()).thenReturn(SECRET);
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setServletPath("/api/v1/users");
+        request.addHeader("Authorization", "Bearer invalid.jwt.token");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilterInternal(request, response, chain);
+
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        assertThat(response.getStatus()).isEqualTo(401);
+    }
+
+    @Test
+    void validToken_setsSecurityContext() throws Exception {
+        when(jwtProperties.getSecret()).thenReturn(SECRET);
+
+        SecretKey key = Keys.hmacShaKeyFor(SECRET.getBytes(StandardCharsets.UTF_8));
+        String token = Jwts.builder()
+                .subject("user-id-123")
+                .claim("email", "user@example.com")
+                .claim("roles", List.of("ADMIN"))
+                .issuedAt(new Date())
+                .expiration(new Date(System.currentTimeMillis() + 3600_000))
+                .signWith(key)
+                .compact();
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setServletPath("/api/v1/users");
+        request.addHeader("Authorization", "Bearer " + token);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilterInternal(request, response, chain);
+
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        assertThat(auth).isNotNull();
+        assertThat(auth.isAuthenticated()).isTrue();
+
+        JwtPrincipal principal = (JwtPrincipal) auth.getPrincipal();
+        assertThat(principal.userId()).isEqualTo("user-id-123");
+        assertThat(principal.email()).isEqualTo("user@example.com");
+        assertThat(auth.getAuthorities()).anyMatch(a -> a.getAuthority().equals("ROLE_ADMIN"));
+    }
+
+    @Test
+    void expiredToken_returns401() throws Exception {
+        when(jwtProperties.getSecret()).thenReturn(SECRET);
+
+        SecretKey key = Keys.hmacShaKeyFor(SECRET.getBytes(StandardCharsets.UTF_8));
+        String token = Jwts.builder()
+                .subject("user-id-123")
+                .claim("email", "user@example.com")
+                .claim("roles", List.of("ADMIN"))
+                .issuedAt(new Date(System.currentTimeMillis() - 7200_000))
+                .expiration(new Date(System.currentTimeMillis() - 3600_000))
+                .signWith(key)
+                .compact();
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setServletPath("/api/v1/users");
+        request.addHeader("Authorization", "Bearer " + token);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilterInternal(request, response, chain);
+
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        assertThat(response.getStatus()).isEqualTo(401);
+        assertThat(response.getContentType()).isEqualTo("application/json");
+        assertThat(response.getContentAsString()).contains("INVALID_OR_EXPIRED_TOKEN");
+    }
+
+    @Test
+    void malformedToken_returns401() throws Exception {
+        when(jwtProperties.getSecret()).thenReturn(SECRET);
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setServletPath("/api/v1/users");
+        request.addHeader("Authorization", "Bearer not.a.valid.jwt.at.all");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilterInternal(request, response, chain);
+
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        assertThat(response.getStatus()).isEqualTo(401);
+        assertThat(response.getContentAsString()).contains("INVALID_OR_EXPIRED_TOKEN");
+    }
+
+    @Test
+    void tokenWithNullRoles_setsEmptyAuthorities() throws Exception {
+        when(jwtProperties.getSecret()).thenReturn(SECRET);
+
+        SecretKey key = Keys.hmacShaKeyFor(SECRET.getBytes(StandardCharsets.UTF_8));
+        String token = Jwts.builder()
+                .subject("user-id-456")
+                .claim("email", "noroles@example.com")
+                // no roles claim at all
+                .issuedAt(new Date())
+                .expiration(new Date(System.currentTimeMillis() + 3600_000))
+                .signWith(key)
+                .compact();
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setServletPath("/api/v1/users");
+        request.addHeader("Authorization", "Bearer " + token);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilterInternal(request, response, chain);
+
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        assertThat(auth).isNotNull();
+        assertThat(auth.getAuthorities()).isEmpty();
+    }
+
+    @Test
+    void headerWithoutBearerPrefix_passesThrough() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setServletPath("/api/v1/users");
+        request.addHeader("Authorization", "Basic dXNlcjpwYXNz");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilterInternal(request, response, chain);
+
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        assertThat(response.getStatus()).isEqualTo(200);
+    }
+
+    @Test
+    void validToken_withRolePrefixed_doesNotDoublePrefix() throws Exception {
+        when(jwtProperties.getSecret()).thenReturn(SECRET);
+
+        SecretKey key = Keys.hmacShaKeyFor(SECRET.getBytes(StandardCharsets.UTF_8));
+        String token = Jwts.builder()
+                .subject("user-id-789")
+                .claim("email", "prefixed@example.com")
+                .claim("roles", List.of("ROLE_MANAGER"))
+                .issuedAt(new Date())
+                .expiration(new Date(System.currentTimeMillis() + 3600_000))
+                .signWith(key)
+                .compact();
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setServletPath("/api/v1/users");
+        request.addHeader("Authorization", "Bearer " + token);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilterInternal(request, response, chain);
+
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        assertThat(auth).isNotNull();
+        assertThat(auth.getAuthorities()).anyMatch(a -> a.getAuthority().equals("ROLE_MANAGER"));
+        assertThat(auth.getAuthorities()).noneMatch(a -> a.getAuthority().equals("ROLE_ROLE_MANAGER"));
+    }
+
+    @Test
+    void shouldNotFilter_loginPath_returnsTrue() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setServletPath("/api/v1/auth/login");
+        assertThat(filter.shouldNotFilter(request)).isTrue();
+    }
+
+    @Test
+    void shouldNotFilter_refreshPath_returnsTrue() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setServletPath("/api/v1/auth/refresh");
+        assertThat(filter.shouldNotFilter(request)).isTrue();
+    }
+
+    @Test
+    void shouldNotFilter_protectedPath_returnsFalse() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setServletPath("/api/v1/users");
+        assertThat(filter.shouldNotFilter(request)).isFalse();
+    }
+
+    @Test
+    void tokenWithSingleStringRole_extractsCorrectly() throws Exception {
+        when(jwtProperties.getSecret()).thenReturn(SECRET);
+
+        SecretKey key = Keys.hmacShaKeyFor(SECRET.getBytes(StandardCharsets.UTF_8));
+        // Build token with roles as a single string (not a list)
+        String token = Jwts.builder()
+                .subject("user-single-role")
+                .claim("email", "single@example.com")
+                .claim("roles", "USER")
+                .issuedAt(new Date())
+                .expiration(new Date(System.currentTimeMillis() + 3600_000))
+                .signWith(key)
+                .compact();
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setServletPath("/api/v1/users");
+        request.addHeader("Authorization", "Bearer " + token);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilterInternal(request, response, chain);
+
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        assertThat(auth).isNotNull();
+        assertThat(auth.getAuthorities()).anyMatch(a -> a.getAuthority().equals("ROLE_USER"));
+    }
+}

--- a/src/test/java/com/logistics/authentication/infrastructure/adapter/out/audit/LoginAuditJdbcAdapterTest.java
+++ b/src/test/java/com/logistics/authentication/infrastructure/adapter/out/audit/LoginAuditJdbcAdapterTest.java
@@ -1,0 +1,40 @@
+package com.logistics.authentication.infrastructure.adapter.out.audit;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.PreparedStatementCreator;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class LoginAuditJdbcAdapterTest {
+
+    @Mock
+    private JdbcTemplate jdbcTemplate;
+
+    @InjectMocks
+    private LoginAuditJdbcAdapter adapter;
+
+    @Test
+    void recordLoginAttempt_callsJdbcTemplateUpdate() {
+        UUID userId = UUID.randomUUID();
+
+        adapter.recordLoginAttempt(userId, "user@example.com", true, null);
+
+        verify(jdbcTemplate).update(any(PreparedStatementCreator.class));
+    }
+
+    @Test
+    void recordLoginAttempt_withNullUserId_callsJdbcTemplateUpdate() {
+        adapter.recordLoginAttempt(null, "unknown@example.com", false, "USER_NOT_FOUND");
+
+        verify(jdbcTemplate).update(any(PreparedStatementCreator.class));
+    }
+}

--- a/src/test/java/com/logistics/authentication/infrastructure/adapter/out/crypto/OpaqueRefreshTokenGeneratorTest.java
+++ b/src/test/java/com/logistics/authentication/infrastructure/adapter/out/crypto/OpaqueRefreshTokenGeneratorTest.java
@@ -1,0 +1,36 @@
+package com.logistics.authentication.infrastructure.adapter.out.crypto;
+
+import java.util.Base64;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OpaqueRefreshTokenGeneratorTest {
+
+    private final OpaqueRefreshTokenGenerator generator = new OpaqueRefreshTokenGenerator();
+
+    @Test
+    void generate_returnsNonNullNonBlankToken() {
+        String token = generator.generate();
+
+        assertThat(token).isNotNull().isNotBlank();
+    }
+
+    @Test
+    void generate_returnsBase64UrlEncodedToken() {
+        String token = generator.generate();
+
+        // Should decode without exception; URL-safe Base64 without padding
+        byte[] decoded = Base64.getUrlDecoder().decode(token);
+        assertThat(decoded).hasSize(32);
+    }
+
+    @Test
+    void generate_producesDifferentTokensOnEachCall() {
+        String token1 = generator.generate();
+        String token2 = generator.generate();
+
+        assertThat(token1).isNotEqualTo(token2);
+    }
+}

--- a/src/test/java/com/logistics/authentication/infrastructure/adapter/out/crypto/Sha256HexTest.java
+++ b/src/test/java/com/logistics/authentication/infrastructure/adapter/out/crypto/Sha256HexTest.java
@@ -1,0 +1,32 @@
+package com.logistics.authentication.infrastructure.adapter.out.crypto;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class Sha256HexTest {
+
+    @Test
+    void of_returnsConsistentHashForSameInput() {
+        String hash1 = Sha256Hex.of("hello");
+        String hash2 = Sha256Hex.of("hello");
+
+        assertThat(hash1).isEqualTo(hash2);
+    }
+
+    @Test
+    void of_returnsDifferentHashesForDifferentInputs() {
+        String hash1 = Sha256Hex.of("hello");
+        String hash2 = Sha256Hex.of("world");
+
+        assertThat(hash1).isNotEqualTo(hash2);
+    }
+
+    @Test
+    void of_returns64CharHexString() {
+        String hash = Sha256Hex.of("test-input");
+
+        assertThat(hash).hasSize(64);
+        assertThat(hash).matches("[0-9a-f]{64}");
+    }
+}

--- a/src/test/java/com/logistics/authentication/infrastructure/adapter/out/persistence/RefreshTokenPersistenceAdapterTest.java
+++ b/src/test/java/com/logistics/authentication/infrastructure/adapter/out/persistence/RefreshTokenPersistenceAdapterTest.java
@@ -1,0 +1,94 @@
+package com.logistics.authentication.infrastructure.adapter.out.persistence;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.logistics.authentication.application.port.out.RefreshTokenRepositoryPort.RefreshTokenActive;
+import com.logistics.authentication.infrastructure.adapter.out.persistence.entity.RefreshTokenEntity;
+import com.logistics.authentication.infrastructure.adapter.out.persistence.repository.RefreshTokenJpaRepository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RefreshTokenPersistenceAdapterTest {
+
+    @Mock
+    private RefreshTokenJpaRepository jpaRepository;
+
+    @Mock
+    private Clock clock;
+
+    @InjectMocks
+    private RefreshTokenPersistenceAdapter adapter;
+
+    @Test
+    void save_persistsTokenAndReturnsId() {
+        UUID userId = UUID.randomUUID();
+        String hash = "abc123hash";
+        Instant expiresAt = Instant.now().plusSeconds(3600);
+        Instant now = Instant.parse("2026-01-01T00:00:00Z");
+
+        when(clock.instant()).thenReturn(now);
+
+        ArgumentCaptor<RefreshTokenEntity> captor = ArgumentCaptor.forClass(RefreshTokenEntity.class);
+        when(jpaRepository.save(captor.capture())).thenAnswer(inv -> inv.getArgument(0));
+
+        UUID result = adapter.save(userId, hash, expiresAt);
+
+        assertThat(result).isNotNull();
+        RefreshTokenEntity saved = captor.getValue();
+        assertThat(saved.getUserId()).isEqualTo(userId);
+        assertThat(saved.getTokenHash()).isEqualTo(hash);
+        assertThat(saved.getExpiresAt()).isEqualTo(expiresAt);
+        assertThat(saved.getCreatedAt()).isEqualTo(now);
+    }
+
+    @Test
+    void findActiveByTokenHash_returnsMappedResult() {
+        UUID tokenId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+        Instant now = Instant.now();
+
+        RefreshTokenEntity entity = RefreshTokenEntity.create(
+                tokenId, userId, "hash", now.plusSeconds(3600), now);
+        when(jpaRepository.findActiveByHash("hash", now)).thenReturn(Optional.of(entity));
+
+        Optional<RefreshTokenActive> result = adapter.findActiveByTokenHash("hash", now);
+
+        assertThat(result).isPresent();
+        assertThat(result.get().id()).isEqualTo(tokenId);
+        assertThat(result.get().userId()).isEqualTo(userId);
+    }
+
+    @Test
+    void findActiveByTokenHash_returnsEmptyWhenNotFound() {
+        Instant now = Instant.now();
+        when(jpaRepository.findActiveByHash("missing", now)).thenReturn(Optional.empty());
+
+        Optional<RefreshTokenActive> result = adapter.findActiveByTokenHash("missing", now);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void revokeAllForUser_delegatesToRepository() {
+        UUID userId = UUID.randomUUID();
+
+        adapter.revokeAllForUser(userId);
+
+        verify(jpaRepository).revokeAllActiveByUserId(userId);
+    }
+}

--- a/src/test/java/com/logistics/authentication/infrastructure/adapter/out/persistence/UserPersistenceAdapterTest.java
+++ b/src/test/java/com/logistics/authentication/infrastructure/adapter/out/persistence/UserPersistenceAdapterTest.java
@@ -1,0 +1,89 @@
+package com.logistics.authentication.infrastructure.adapter.out.persistence;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.logistics.authentication.domain.model.UserAccount;
+import com.logistics.authentication.infrastructure.adapter.out.persistence.entity.UserEntity;
+import com.logistics.authentication.infrastructure.adapter.out.persistence.mapper.UserMapper;
+import com.logistics.authentication.infrastructure.adapter.out.persistence.repository.UserJpaRepository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class UserPersistenceAdapterTest {
+
+    @Mock
+    private UserJpaRepository userJpaRepository;
+
+    @Mock
+    private UserMapper userMapper;
+
+    @InjectMocks
+    private UserPersistenceAdapter adapter;
+
+    @Test
+    void findByEmail_returnsMappedDomainUser() {
+        UserEntity entity = new UserEntity();
+        entity.setId(UUID.randomUUID());
+        entity.setEmail("user@example.com");
+
+        UserAccount domainUser = UserAccount.builder()
+                .id(entity.getId())
+                .email("user@example.com")
+                .passwordHash("hashed")
+                .roles(Set.of("ADMIN"))
+                .enabled(true)
+                .failedLoginAttempts(0)
+                .build();
+
+        when(userJpaRepository.findByEmailIgnoreCase("user@example.com")).thenReturn(Optional.of(entity));
+        when(userMapper.toDomain(entity)).thenReturn(domainUser);
+
+        Optional<UserAccount> result = adapter.findByEmail("user@example.com");
+
+        assertThat(result).isPresent();
+        assertThat(result.get().getEmail()).isEqualTo("user@example.com");
+        verify(userJpaRepository).findByEmailIgnoreCase("user@example.com");
+        verify(userMapper).toDomain(entity);
+    }
+
+    @Test
+    void findByEmail_returnsEmptyWhenNotFound() {
+        when(userJpaRepository.findByEmailIgnoreCase("unknown@example.com")).thenReturn(Optional.empty());
+
+        Optional<UserAccount> result = adapter.findByEmail("unknown@example.com");
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void resetFailedLogin_delegatesToRepository() {
+        UUID userId = UUID.randomUUID();
+
+        adapter.resetFailedLogin(userId);
+
+        verify(userJpaRepository).resetFailedLogin(userId);
+    }
+
+    @Test
+    void registerFailedLogin_delegatesToRepository() {
+        UUID userId = UUID.randomUUID();
+        Instant lockedUntil = Instant.now().plusSeconds(300);
+
+        adapter.registerFailedLogin(userId, 3, lockedUntil);
+
+        verify(userJpaRepository).updateFailedLogin(userId, 3, lockedUntil);
+    }
+}

--- a/src/test/java/com/logistics/authentication/infrastructure/adapter/out/persistence/UserRoleStatsAdapterTest.java
+++ b/src/test/java/com/logistics/authentication/infrastructure/adapter/out/persistence/UserRoleStatsAdapterTest.java
@@ -1,0 +1,53 @@
+package com.logistics.authentication.infrastructure.adapter.out.persistence;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.logistics.authentication.domain.readmodel.RoleUserCount;
+import com.logistics.authentication.infrastructure.adapter.out.persistence.repository.UserJpaRepository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class UserRoleStatsAdapterTest {
+
+    @Mock
+    private UserJpaRepository userJpaRepository;
+
+    @InjectMocks
+    private UserRoleStatsAdapter adapter;
+
+    @Test
+    void countUsersGroupedByRole_delegatesToJpaAndMapsResults() {
+        List<Object[]> rawRows = List.of(
+                new Object[]{"ADMIN", 5L},
+                new Object[]{"USER", 10L}
+        );
+        when(userJpaRepository.countUsersGroupedByRole()).thenReturn(rawRows);
+
+        List<RoleUserCount> result = adapter.countUsersGroupedByRole();
+
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).roleName()).isEqualTo("ADMIN");
+        assertThat(result.get(0).userCount()).isEqualTo(5L);
+        assertThat(result.get(1).roleName()).isEqualTo("USER");
+        assertThat(result.get(1).userCount()).isEqualTo(10L);
+        verify(userJpaRepository).countUsersGroupedByRole();
+    }
+
+    @Test
+    void countUsersGroupedByRole_returnsEmptyListWhenNoData() {
+        when(userJpaRepository.countUsersGroupedByRole()).thenReturn(List.of());
+
+        List<RoleUserCount> result = adapter.countUsersGroupedByRole();
+
+        assertThat(result).isEmpty();
+    }
+}

--- a/src/test/java/com/logistics/authentication/infrastructure/adapter/out/persistence/mapper/UserMapperTest.java
+++ b/src/test/java/com/logistics/authentication/infrastructure/adapter/out/persistence/mapper/UserMapperTest.java
@@ -1,0 +1,85 @@
+package com.logistics.authentication.infrastructure.adapter.out.persistence.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+import com.logistics.authentication.domain.model.UserAccount;
+import com.logistics.authentication.infrastructure.adapter.out.persistence.entity.RoleEntity;
+import com.logistics.authentication.infrastructure.adapter.out.persistence.entity.UserEntity;
+
+class UserMapperTest {
+
+    private final UserMapper mapper = new UserMapper();
+
+    @Test
+    void toDomain_mapsEntityWithRolesCorrectly() {
+        UUID userId = UUID.randomUUID();
+        UserEntity entity = new UserEntity();
+        entity.setId(userId);
+        entity.setEmail("admin@logistics.com");
+        entity.setPasswordHash("$2a$10$hashedpassword");
+        entity.setEnabled(true);
+        entity.setFailedLoginAttempts(2);
+        entity.setLockedUntil(Instant.parse("2026-12-31T23:59:59Z"));
+
+        RoleEntity role1 = new RoleEntity();
+        role1.setId(UUID.randomUUID());
+        role1.setName("ROLE_ADMIN");
+
+        RoleEntity role2 = new RoleEntity();
+        role2.setId(UUID.randomUUID());
+        role2.setName("ROLE_USER");
+
+        entity.setRoles(Set.of(role1, role2));
+
+        UserAccount domain = mapper.toDomain(entity);
+
+        assertThat(domain.getId()).isEqualTo(userId);
+        assertThat(domain.getEmail()).isEqualTo("admin@logistics.com");
+        assertThat(domain.getPasswordHash()).isEqualTo("$2a$10$hashedpassword");
+        assertThat(domain.isEnabled()).isTrue();
+        assertThat(domain.getFailedLoginAttempts()).isEqualTo(2);
+        assertThat(domain.getLockedUntil()).isEqualTo(Instant.parse("2026-12-31T23:59:59Z"));
+        assertThat(domain.getRoles()).containsExactlyInAnyOrder("ROLE_ADMIN", "ROLE_USER");
+    }
+
+    @Test
+    void toDomain_mapsEntityWithEmptyRoles() {
+        UserEntity entity = new UserEntity();
+        entity.setId(UUID.randomUUID());
+        entity.setEmail("noroles@test.com");
+        entity.setPasswordHash("hash");
+        entity.setEnabled(true);
+        entity.setFailedLoginAttempts(0);
+        entity.setLockedUntil(null);
+        entity.setRoles(new HashSet<>());
+
+        UserAccount domain = mapper.toDomain(entity);
+
+        assertThat(domain.getRoles()).isEmpty();
+        assertThat(domain.getLockedUntil()).isNull();
+    }
+
+    @Test
+    void toDomain_mapsDisabledUser() {
+        UserEntity entity = new UserEntity();
+        entity.setId(UUID.randomUUID());
+        entity.setEmail("disabled@test.com");
+        entity.setPasswordHash("hash");
+        entity.setEnabled(false);
+        entity.setFailedLoginAttempts(5);
+        entity.setLockedUntil(null);
+        entity.setRoles(new HashSet<>());
+
+        UserAccount domain = mapper.toDomain(entity);
+
+        assertThat(domain.isEnabled()).isFalse();
+        assertThat(domain.getFailedLoginAttempts()).isEqualTo(5);
+    }
+}

--- a/src/test/java/com/logistics/authentication/infrastructure/adapter/out/security/JwtTokenProviderAdapterTest.java
+++ b/src/test/java/com/logistics/authentication/infrastructure/adapter/out/security/JwtTokenProviderAdapterTest.java
@@ -1,0 +1,106 @@
+package com.logistics.authentication.infrastructure.adapter.out.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import javax.crypto.SecretKey;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.logistics.authentication.domain.model.UserAccount;
+import com.logistics.authentication.infrastructure.config.JwtProperties;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+
+class JwtTokenProviderAdapterTest {
+
+    private static final String SECRET = "test-secret-key-that-is-at-least-32-bytes-long!!";
+    private static final long ACCESS_TTL = 3600L;
+    private static final long REFRESH_TTL = 604800L;
+
+    private JwtTokenProviderAdapter adapter;
+    private SecretKey key;
+
+    @BeforeEach
+    void setUp() {
+        JwtProperties props = new JwtProperties();
+        props.setSecret(SECRET);
+        props.setAccessTokenTtlSeconds(ACCESS_TTL);
+        props.setRefreshTokenTtlSeconds(REFRESH_TTL);
+
+        adapter = new JwtTokenProviderAdapter(props);
+        key = Keys.hmacShaKeyFor(SECRET.getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void createAccessToken_containsExpectedClaims() {
+        UUID userId = UUID.randomUUID();
+        UserAccount user = UserAccount.builder()
+                .id(userId)
+                .email("admin@logistics.com")
+                .passwordHash("hash")
+                .roles(Set.of("ROLE_ADMIN"))
+                .enabled(true)
+                .failedLoginAttempts(0)
+                .lockedUntil(null)
+                .build();
+
+        String token = adapter.createAccessToken(user);
+
+        Claims claims = Jwts.parser()
+                .verifyWith(key)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+
+        assertThat(claims.getSubject()).isEqualTo(userId.toString());
+        assertThat(claims.get("email", String.class)).isEqualTo("admin@logistics.com");
+        @SuppressWarnings("unchecked")
+        List<String> roles = claims.get("roles", List.class);
+        assertThat(roles).contains("ROLE_ADMIN");
+        assertThat(claims.getIssuedAt()).isNotNull();
+        assertThat(claims.getExpiration()).isNotNull();
+    }
+
+    @Test
+    void createAccessToken_expirationMatchesTtl() {
+        UserAccount user = UserAccount.builder()
+                .id(UUID.randomUUID())
+                .email("user@test.com")
+                .passwordHash("hash")
+                .roles(Set.of("ROLE_USER"))
+                .enabled(true)
+                .failedLoginAttempts(0)
+                .lockedUntil(null)
+                .build();
+
+        String token = adapter.createAccessToken(user);
+
+        Claims claims = Jwts.parser()
+                .verifyWith(key)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+
+        long diffSeconds = (claims.getExpiration().getTime() - claims.getIssuedAt().getTime()) / 1000;
+        assertThat(diffSeconds).isEqualTo(ACCESS_TTL);
+    }
+
+    @Test
+    void getAccessTokenTtlSeconds_returnsConfiguredValue() {
+        assertThat(adapter.getAccessTokenTtlSeconds()).isEqualTo(ACCESS_TTL);
+    }
+
+    @Test
+    void getRefreshTokenTtlSeconds_returnsConfiguredValue() {
+        assertThat(adapter.getRefreshTokenTtlSeconds()).isEqualTo(REFRESH_TTL);
+    }
+}

--- a/src/test/java/com/logistics/authentication/infrastructure/adapter/out/security/PasswordEncoderAdapterTest.java
+++ b/src/test/java/com/logistics/authentication/infrastructure/adapter/out/security/PasswordEncoderAdapterTest.java
@@ -1,0 +1,39 @@
+package com.logistics.authentication.infrastructure.adapter.out.security;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PasswordEncoderAdapterTest {
+
+    @Mock
+    private PasswordEncoder delegate;
+
+    @InjectMocks
+    private PasswordEncoderAdapter adapter;
+
+    @Test
+    void matches_returnsTrueForCorrectPassword() {
+        when(delegate.matches("rawPass", "encodedPass")).thenReturn(true);
+
+        boolean result = adapter.matches("rawPass", "encodedPass");
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void matches_returnsFalseForWrongPassword() {
+        when(delegate.matches("wrongPass", "encodedPass")).thenReturn(false);
+
+        boolean result = adapter.matches("wrongPass", "encodedPass");
+
+        assertThat(result).isFalse();
+    }
+}

--- a/src/test/java/com/logistics/authentication/infrastructure/adapter/out/security/RefreshTokenIssuerAdapterTest.java
+++ b/src/test/java/com/logistics/authentication/infrastructure/adapter/out/security/RefreshTokenIssuerAdapterTest.java
@@ -1,0 +1,43 @@
+package com.logistics.authentication.infrastructure.adapter.out.security;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.logistics.authentication.infrastructure.adapter.out.crypto.OpaqueRefreshTokenGenerator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RefreshTokenIssuerAdapterTest {
+
+    @Mock
+    private OpaqueRefreshTokenGenerator generator;
+
+    @InjectMocks
+    private RefreshTokenIssuerAdapter adapter;
+
+    @Test
+    void newOpaqueToken_delegatesToGenerator() {
+        when(generator.generate()).thenReturn("opaque-token-value");
+
+        String result = adapter.newOpaqueToken();
+
+        assertThat(result).isEqualTo("opaque-token-value");
+        verify(generator).generate();
+    }
+
+    @Test
+    void sha256Hex_delegatesToSha256HexUtility() {
+        // Sha256Hex is a static utility, so we verify correctness by checking output
+        String result = adapter.sha256Hex("test-token");
+
+        assertThat(result).isNotNull().hasSize(64);
+        // Should be consistent
+        assertThat(result).isEqualTo(adapter.sha256Hex("test-token"));
+    }
+}

--- a/src/test/java/com/logistics/authentication/karate/AuthKarateTest.java
+++ b/src/test/java/com/logistics/authentication/karate/AuthKarateTest.java
@@ -1,0 +1,18 @@
+package com.logistics.authentication.karate;
+
+import com.intuit.karate.junit5.Karate;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class AuthKarateTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Karate.Test
+    Karate testAuth() {
+        return Karate.run("classpath:karate/auth/auth-login.feature")
+                .systemProperty("local.server.port", String.valueOf(port));
+    }
+}

--- a/src/test/java/com/logistics/authentication/karate/H2StoredProcedures.java
+++ b/src/test/java/com/logistics/authentication/karate/H2StoredProcedures.java
@@ -1,0 +1,29 @@
+package com.logistics.authentication.karate;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.UUID;
+
+/**
+ * Simula los stored procedures de PostgreSQL para que funcionen en H2 durante tests.
+ */
+public class H2StoredProcedures {
+
+    public static void spLogLoginEvent(Connection conn, UUID userId, String email, boolean success, String reason)
+            throws SQLException {
+        try (PreparedStatement ps = conn.prepareStatement(
+                "INSERT INTO security_login_events (id, user_id, email, success, reason, occurred_at) " +
+                "VALUES (RANDOM_UUID(), ?, ?, ?, ?, CURRENT_TIMESTAMP)")) {
+            if (userId == null) {
+                ps.setNull(1, java.sql.Types.OTHER);
+            } else {
+                ps.setObject(1, userId);
+            }
+            ps.setString(2, email);
+            ps.setBoolean(3, success);
+            ps.setString(4, reason);
+            ps.executeUpdate();
+        }
+    }
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,2 +1,16 @@
-# Perfil de pruebas: desactiva validaciones de arranque estrictas (p. ej. longitud de JWT en tests aislados).
 spring.profiles.active=test
+spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MODE=PostgreSQL
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.defer-datasource-initialization=true
+spring.sql.init.mode=always
+spring.flyway.enabled=false
+app.jwt.secret=test-secret-key-that-is-at-least-32-bytes-long!!
+app.jwt.access-token-ttl-seconds=3600
+app.jwt.refresh-token-ttl-seconds=604800
+app.cors.allowed-origins=http://localhost:3000
+app.security.hsts-enabled=false
+app.security.login-rate-limit-per-minute=100
+spring.rabbitmq.listener.simple.auto-startup=false

--- a/src/test/resources/data.sql
+++ b/src/test/resources/data.sql
@@ -1,0 +1,19 @@
+-- Seed data para tests de integración (Karate)
+-- Password: password123 (BCrypt cost 10)
+INSERT INTO auth_roles (id, name) VALUES
+    ('11111111-1111-1111-1111-111111111111', 'ROLE_ADMIN'),
+    ('22222222-2222-2222-2222-222222222222', 'ROLE_OPERATOR');
+
+INSERT INTO auth_users (id, email, password_hash, enabled, failed_login_attempts, created_at, updated_at)
+VALUES (
+    '33333333-3333-3333-3333-333333333333',
+    'admin@logistics.com',
+    '$2a$10$dXJ3SW6G7P50lGmMkkmwe.20cQQubK3.HZWzG3YB1tlRy.fqvM/BG',
+    TRUE,
+    0,
+    CURRENT_TIMESTAMP,
+    CURRENT_TIMESTAMP
+);
+
+INSERT INTO auth_user_roles (user_id, role_id) VALUES
+    ('33333333-3333-3333-3333-333333333333', '11111111-1111-1111-1111-111111111111');

--- a/src/test/resources/karate-config.js
+++ b/src/test/resources/karate-config.js
@@ -1,0 +1,7 @@
+function fn() {
+  var port = karate.properties['local.server.port'] || '8080';
+  var config = {
+    baseUrl: 'http://localhost:' + port
+  };
+  return config;
+}

--- a/src/test/resources/karate/auth/auth-login.feature
+++ b/src/test/resources/karate/auth/auth-login.feature
@@ -1,0 +1,42 @@
+Feature: Authentication Login API
+  Background:
+    * url baseUrl
+
+  # CP-15-01: Login with valid credentials
+  Scenario: Login with valid credentials returns access and refresh tokens
+    Given path '/api/v1/auth/login'
+    And request { email: 'admin@logistics.com', password: 'password' }
+    When method POST
+    Then status 200
+    And match response.accessToken == '#string'
+    And match response.tokenType == 'Bearer'
+    And match response.expiresIn == '#number'
+    And match response.roles == '#array'
+    And match response.refreshToken == '#string'
+    And match response.refreshExpiresIn == '#number'
+
+  # CP-15-02: Login denied - wrong password
+  Scenario: Login with wrong password returns 401
+    Given path '/api/v1/auth/login'
+    And request { email: 'admin@logistics.com', password: 'wrongpassword' }
+    When method POST
+    Then status 401
+    And match response.errorCode == '#string'
+    And match response.message == '#string'
+
+  # CP-15-03: Login denied - unregistered email
+  Scenario: Login with unregistered email returns 401
+    Given path '/api/v1/auth/login'
+    And request { email: 'noexiste@logistics.com', password: 'password123' }
+    When method POST
+    Then status 401
+    And match response.errorCode == '#string'
+    And match response.message == '#string'
+
+  # CP-15-04: Login denied - missing data
+  Scenario: Login with missing data returns 400
+    Given path '/api/v1/auth/login'
+    And request { email: '', password: '' }
+    When method POST
+    Then status 400
+    And match response.errorCode == 'VALIDATION_ERROR'

--- a/src/test/resources/schema.sql
+++ b/src/test/resources/schema.sql
@@ -1,0 +1,12 @@
+-- Tabla de auditoría (no gestionada por JPA)
+CREATE TABLE IF NOT EXISTS security_login_events (
+    id UUID DEFAULT RANDOM_UUID() PRIMARY KEY,
+    user_id UUID,
+    email VARCHAR(255) NOT NULL,
+    success BOOLEAN NOT NULL,
+    reason VARCHAR(500),
+    occurred_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+-- Stored procedure H2-compatible
+CREATE ALIAS IF NOT EXISTS sp_log_login_event FOR "com.logistics.authentication.karate.H2StoredProcedures.spLogLoginEvent";


### PR DESCRIPTION
…ate) for authentication-service

- 87 tests total: 83 unit/controller tests + 4 Karate API tests
- Coverage: Instructions 82.3%, Lines 90.4%, Methods 88.0%
- JaCoCo plugin configured for coverage reports
- Tests cover: LoginService, RefreshTokenService, AuthController, AdminStatsController, JwtAuthenticationFilter, LoginRateLimitFilter, TraceIdFilter, GlobalExceptionHandler, persistence adapters, crypto utilities, mappers, and domain models
- Karate features: CP-15-01 to CP-15-04 (login scenarios from SQA plan)
- H2 test configuration with seed data and stored procedure simulation