### PR TITLE
fix(security): permitir acceso público al endpoint de registro

### DIFF
--- a/src/main/java/com/logistics/authentication/infrastructure/config/SecurityConfig.java
+++ b/src/main/java/com/logistics/authentication/infrastructure/config/SecurityConfig.java
@@ -62,7 +62,7 @@ public class SecurityConfig {
 						}))
 				.authorizeHttpRequests(auth -> auth
 						.requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
-						.requestMatchers("/api/v1/auth/login", "/api/v1/auth/refresh").permitAll()
+						.requestMatchers("/api/v1/auth/login", "/api/v1/auth/refresh", "/api/v1/auth/register").permitAll()
 						.requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
 						.requestMatchers("/error").permitAll()
 						.requestMatchers("/api/v1/admin/**").hasRole("ADMIN")


### PR DESCRIPTION
## Problema
El API Gateway expone `POST /api/auth/register` como ruta **pública**, pero la `SecurityConfig` de `authentication-service` solo incluía `/api/v1/auth/login` y `/api/v1/auth/refresh` en `permitAll()`. Por eso `/api/v1/auth/register` caía en `anyRequest().authenticated()` y devolvía **401** — el auto-registro de usuarios quedaba inaccesible incluso a través del gateway.

## Solución
Agregar `/api/v1/auth/register` a la lista `permitAll()` (1 línea).

## Verificación (ambiente local)
- `POST /api/v1/auth/register` directo (auth:8080) → **201** (antes 401)
- `POST /api/auth/register` vía gateway → **201** (antes 401)
- El usuario nuevo queda **PENDING** con `ROLE_OPERATOR`, a la espera de aprobación de un administrador (sin cambios en esa lógica).
- `login` y `refresh` siguen funcionando.

Detectado durante validación QA del ambiente completo. 🤖 Generated with [Claude Code](https://claude.com/claude-code)